### PR TITLE
Remove dependent wait handle

### DIFF
--- a/build/all_header.sh
+++ b/build/all_header.sh
@@ -2,23 +2,6 @@
 
 set -e
 
-function retry()
-{
-  local n=1
-  local try=$1
-  local cmd="${@: 2}"
-
-  until [[ $n -gt $try ]]
-  do
-    echo "attempt number $n:"
-    $cmd && break || {
-      echo "Command Failed..."
-      ((n++))
-      sleep 1;
-    }
-  done
-}
-
 export HOME=${HOME:-"/root"}
 
 ANSIBLE_PLAYBOOKS="%%ANSIBLE_PLAYBOOKS%%"

--- a/build/controller_primary.sh
+++ b/build/controller_primary.sh
@@ -45,26 +45,70 @@ if [ $SWIFT_ENABLED -eq 1 ]; then
   sed -i "s/__CLUSTER_PREFIX__/%%CLUSTER_PREFIX%%/g" $swift_config
 fi
 
+# here we create a separate script incase run_ansible paramater is false and
+# you want to re-run the correct set of playbooks at a later time
+cd rpc_deployment
+cat >> run_ansible.sh << "EOF"
+#!/bin/bash
+
+set -e
+
+function retry()
+{
+  local n=1
+  local try=$1
+  local cmd="${@: 2}"
+
+  until [[ $n -gt $try ]]
+  do
+    echo "attempt number $n:"
+    $cmd && break || {
+      echo "Command Failed..."
+      ((n++))
+      sleep 1;
+    }
+  done
+}
+
+user_variables=${user_variables:-"/etc/rpc_deploy/user_variables.yml"}
+
+timeout=$(($(date +%s) + 300))
+
+until ansible hosts -m ping > /dev/null 2>&1; do
+  if [ $(date +%s) -gt $timeout ]; then
+    echo "Timed out waiting for nodes to become accessible ..."
+    exit 1
+  fi
+done
+
+retry 3 ansible-playbook -e @${user_variables} playbooks/setup/host-setup.yml
+retry 3 ansible-playbook -e @${user_variables} playbooks/infrastructure/haproxy-install.yml
+EOF
+
+if [ "$ANSIBLE_PLAYBOOKS" = "all" ] || [ "$ANSIBLE_PLAYBOOKS" = "all+swift" ]; then
+  cat >> run_ansible.sh << "EOF"
+retry 3 ansible-playbook -e @${user_variables} playbooks/infrastructure/infrastructure-setup.yml \
+                                               playbooks/openstack/openstack-setup.yml
+EOF
+fi
+
+if [ "$ANSIBLE_PLAYBOOKS" = "minimal" ] || [ "$ANSIBLE_PLAYBOOKS" = "minimal+swift" ]; then
+  cat >> run_ansible.sh << "EOF"
+egrep -v 'rpc-support-all.yml|rsyslog-config.yml' playbooks/openstack/openstack-setup.yml > \
+                                                  playbooks/openstack/openstack-setup-no-logging.yml
+retry 3 ansible-playbook -e @${user_variables} playbooks/infrastructure/memcached-install.yml \
+                                               playbooks/infrastructure/galera-install.yml \
+                                               playbooks/infrastructure/rabbit-install.yml
+retry 3 ansible-playbook -e @${user_variables} playbooks/openstack/openstack-setup-no-logging.yml
+EOF
+fi
+
+if [ $SWIFT_ENABLED -eq 1 ]; then
+  cat >> run_ansible.sh << "EOF"
+retry 3 ansible-playbook -e @${user_variables} playbooks/openstack/swift-all.yml
+EOF
+fi
+
 if [ $RUN_ANSIBLE -eq 1 ]; then
-  cd rpc_deployment
-  retry 3 ansible-playbook -e @${user_variables} playbooks/setup/host-setup.yml
-  retry 3 ansible-playbook -e @${user_variables} playbooks/infrastructure/haproxy-install.yml
-
-  if [ "$ANSIBLE_PLAYBOOKS" = "all" ] || [ "$ANSIBLE_PLAYBOOKS" = "all+swift" ]; then
-    retry 3 ansible-playbook -e @${user_variables} playbooks/infrastructure/infrastructure-setup.yml \
-                                                   playbooks/openstack/openstack-setup.yml
-  fi
-
-  if [ "$ANSIBLE_PLAYBOOKS" = "minimal" ] || [ "$ANSIBLE_PLAYBOOKS" = "minimal+swift" ]; then
-    egrep -v 'rpc-support-all.yml|rsyslog-config.yml' playbooks/openstack/openstack-setup.yml > \
-                                                      playbooks/openstack/openstack-setup-no-logging.yml
-    retry 3 ansible-playbook -e @${user_variables} playbooks/infrastructure/memcached-install.yml \
-                                                   playbooks/infrastructure/galera-install.yml \
-                                                   playbooks/infrastructure/rabbit-install.yml
-    retry 3 ansible-playbook -e @${user_variables} playbooks/openstack/openstack-setup-no-logging.yml
-  fi
-
-  if [ $SWIFT_ENABLED -eq 1 ]; then
-    retry 3 ansible-playbook -e @${user_variables} playbooks/openstack/swift-all.yml
-  fi
+  bash run_ansible.sh
 fi

--- a/config_compute_all.sh
+++ b/config_compute_all.sh
@@ -2,23 +2,6 @@
 
 set -e
 
-function retry()
-{
-  local n=1
-  local try=$1
-  local cmd="${@: 2}"
-
-  until [[ $n -gt $try ]]
-  do
-    echo "attempt number $n:"
-    $cmd && break || {
-      echo "Command Failed..."
-      ((n++))
-      sleep 1;
-    }
-  done
-}
-
 export HOME=${HOME:-"/root"}
 
 ANSIBLE_PLAYBOOKS="%%ANSIBLE_PLAYBOOKS%%"

--- a/config_controller_other.sh
+++ b/config_controller_other.sh
@@ -2,23 +2,6 @@
 
 set -e
 
-function retry()
-{
-  local n=1
-  local try=$1
-  local cmd="${@: 2}"
-
-  until [[ $n -gt $try ]]
-  do
-    echo "attempt number $n:"
-    $cmd && break || {
-      echo "Command Failed..."
-      ((n++))
-      sleep 1;
-    }
-  done
-}
-
 export HOME=${HOME:-"/root"}
 
 ANSIBLE_PLAYBOOKS="%%ANSIBLE_PLAYBOOKS%%"

--- a/jenkins/stack-create.sh
+++ b/jenkins/stack-create.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+KEY_NAME="jenkins"
+FLAVOR="performance1-8"
+RPC_GIT_REPO="https://github.com/stackforge/os-ansible-deployment"
+RPC_GIT_VERSION="master"
+HEAT_GIT_REPO="https://github.com/mattt416/rpc_heat"
+HEAT_GIT_VERSION="master"
+CLUSTER_PREFIX="${CLUSTER_PREFIX:-$(date "+%Y%m%d%H%M")}"
+ANSIBLE_PLAYBOOKS="minimal+swift"
+RACKSPACE_CLOUD_USERNAME="${OS_USERNAME}"
+RACKSPACE_CLOUD_API_KEY="${OS_API_KEY}"
+RACKSPACE_CLOUD_AUTH_URL="${OS_AUTH_URL}"
+RACKSPACE_CLOUD_PASSWORD="${OS_PASSWORD}"
+RACKSPACE_CLOUD_TENANT_ID="${OS_TENANT_ID}"
+GLANCE_DEFAULT_STORE="swift"
+GLANCE_SWIFT_STORE_REGION="LON"
+RUN_ANSIBLE="False"
+
+source ~/.openrc
+
+heat stack-create -f rpc_multi_node.yml rpc-${CLUSTER_PREFIX} -P "key_name=${KEY_NAME};rpc_git_version=${RPC_GIT_VERSION};cluster_prefix=${CLUSTER_PREFIX};ansible_playbooks=${ANSIBLE_PLAYBOOKS};rackspace_cloud_username=${RACKSPACE_CLOUD_USERNAME};rackspace_cloud_api_key=${RACKSPACE_CLOUD_API_KEY};rackspace_cloud_auth_url=${RACKSPACE_CLOUD_AUTH_URL};rackspace_cloud_password=${RACKSPACE_CLOUD_PASSWORD};rackspace_cloud_tenant_id=${RACKSPACE_CLOUD_TENANT_ID};glance_default_store=${GLANCE_DEFAULT_STORE};glance_swift_store_region=${GLANCE_SWIFT_STORE_REGION};flavor=${FLAVOR};rpc_git_repo=${RPC_GIT_REPO};heat_git_repo=${HEAT_GIT_REPO};heat_git_version=${HEAT_GIT_VERSION};run_ansible=${RUN_ANSIBLE}" -t 151
+
+exit_status=-1
+
+while [ $exit_status -lt 0 ] ; do
+  sleep 30
+  stack_status=$(heat stack-list 2>&1 | grep rpc-${CLUSTER_PREFIX} | awk -F\| '{print $4}' | sed -e 's/\s//g')
+  if [ "$stack_status" = "CREATE_COMPLETE" ]; then
+    exit_status=0
+  elif [ "$stack_status" = "CREATE_FAILED" ]; then
+    exit_status=1
+  fi
+done
+
+exit $exit_status

--- a/jenkins/stack-delete.sh
+++ b/jenkins/stack-delete.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source ~/.openrc
+
+heat stack-delete rpc-jenkins-${BUILD_NUMBER}

--- a/jenkins/stack-deploy.sh
+++ b/jenkins/stack-deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+source ~/.openrc
+
+ip=$(heat output-show rpc-jenkins-${BUILD_NUMBER} controller1_ip | sed -e 's/"//g')
+cmd="cd /root/ansible-lxc-rpc/rpc_deployment && bash run_ansible.sh"
+
+ssh -l root -i ~/.ssh/jenkins -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $ip $cmd

--- a/rpc_multi_node.yml
+++ b/rpc_multi_node.yml
@@ -115,29 +115,49 @@ parameters:
       - allowed_values: [ DFW, HKG, IAD, LON, ORD, SYD ]
 
 resources:
-  # This wait condition and handle is for the 4 other nodes which the primary
-  # controller depends on.  The primary controller should not start building
-  # until these are all online and ready to roll.
-  dependent_wait:
+  controller1_wait:
     type: "OS::Heat::SwiftSignal"
     properties:
-      handle: { get_resource: dependent_wait_handle }
-      count: 4
-      timeout: 2700
-
-  dependent_wait_handle:
-    type: "OS::Heat::SwiftSignalHandle"
-
-  # This wait condition and handle is to signal the completion of the stack
-  # itself.
-  primary_controller_wait:
-    type: "OS::Heat::SwiftSignal"
-    properties:
-      handle: { get_resource: primary_controller_wait_handle }
+      handle: { get_resource: controller1_wait_handle }
       count: 1
       timeout: 5400
+  controller1_wait_handle:
+    type: "OS::Heat::SwiftSignalHandle"
 
-  primary_controller_wait_handle:
+  controller2_wait:
+    type: "OS::Heat::SwiftSignal"
+    properties:
+      handle: { get_resource: controller2_wait_handle }
+      count: 1
+      timeout: 2700
+  controller2_wait_handle:
+    type: "OS::Heat::SwiftSignalHandle"
+
+  controller3_wait:
+    type: "OS::Heat::SwiftSignal"
+    properties:
+      handle: { get_resource: controller3_wait_handle }
+      count: 1
+      timeout: 2700
+  controller3_wait_handle:
+    type: "OS::Heat::SwiftSignalHandle"
+
+  compute1_wait:
+    type: "OS::Heat::SwiftSignal"
+    properties:
+      handle: { get_resource: compute1_wait_handle }
+      count: 1
+      timeout: 2700
+  compute1_wait_handle:
+    type: "OS::Heat::SwiftSignalHandle"
+
+  compute2_wait:
+    type: "OS::Heat::SwiftSignal"
+    properties:
+      handle: { get_resource: compute2_wait_handle }
+      count: 1
+      timeout: 2700
+  compute2_wait_handle:
     type: "OS::Heat::SwiftSignalHandle"
 
   heat_mgmt_vxlan:
@@ -160,9 +180,6 @@ resources:
 
   controller1:
     type: "OS::Nova::Server"
-    # Don't build controller1 until the others are up as the ansible run
-    # will fail if they are down.
-    depends_on: dependent_wait
     properties:
       image: { get_param: image }
       flavor: { get_param: flavor }
@@ -202,7 +219,7 @@ resources:
             "%%GLANCE_DEFAULT_STORE%%": { get_param: glance_default_store }
             "%%GLANCE_SWIFT_STORE_REGION%%": { get_param: glance_swift_store_region }
             "%%RUN_ANSIBLE%%": { get_param: run_ansible }
-            "%%CURL_CLI%%": { get_attr: ['primary_controller_wait_handle', 'curl_cli'] }
+            "%%CURL_CLI%%": { get_attr: ['controller1_wait_handle', 'curl_cli'] }
 
   controller2:
     type: "OS::Nova::Server"
@@ -230,7 +247,7 @@ resources:
             "%%ID%%": "2"
             "%%PUBLIC_KEY%%": { get_file: id_rsa.pub }
             "%%CLUSTER_PREFIX%%": { get_param: cluster_prefix }
-            "%%CURL_CLI%%": { get_attr: ['dependent_wait_handle', 'curl_cli'] }
+            "%%CURL_CLI%%": { get_attr: ['controller2_wait_handle', 'curl_cli'] }
 
   controller3:
     type: "OS::Nova::Server"
@@ -258,7 +275,7 @@ resources:
             "%%ID%%": "3"
             "%%PUBLIC_KEY%%": { get_file: id_rsa.pub }
             "%%CLUSTER_PREFIX%%": { get_param: cluster_prefix }
-            "%%CURL_CLI%%": { get_attr: ['dependent_wait_handle', 'curl_cli'] }
+            "%%CURL_CLI%%": { get_attr: ['controller3_wait_handle', 'curl_cli'] }
 
   compute1:
     type: "OS::Nova::Server"
@@ -286,7 +303,7 @@ resources:
             "%%ID%%": "4"
             "%%PUBLIC_KEY%%": { get_file: id_rsa.pub }
             "%%CLUSTER_PREFIX%%": { get_param: cluster_prefix }
-            "%%CURL_CLI%%": { get_attr: ['dependent_wait_handle', 'curl_cli'] }
+            "%%CURL_CLI%%": { get_attr: ['compute1_wait_handle', 'curl_cli'] }
 
   compute2:
     type: "OS::Nova::Server"
@@ -314,7 +331,7 @@ resources:
             "%%ID%%": "5"
             "%%PUBLIC_KEY%%": { get_file: id_rsa.pub }
             "%%CLUSTER_PREFIX%%": { get_param: cluster_prefix }
-            "%%CURL_CLI%%": { get_attr: ['dependent_wait_handle', 'curl_cli'] }
+            "%%CURL_CLI%%": { get_attr: ['compute2_wait_handle', 'curl_cli'] }
 
 outputs:
   controller1_ip:


### PR DESCRIPTION
Currently, we often see node1 not getting built even though the other
nodes come up and curl swift successfully.  This change, with
@miguelgrinberg, creates 5 individual signals / signal handlers.  We
now also loop an ansible ping (timing out after 5 mins) to verify that
all nodes are up before doing the ansible run.

Lastly, the code that actually does the ansible run is now saved to a
file and that file gets executed.  The reason for this is to allow you
to a) run the appropriate playbooks even if you set run_ansible to
False and b) allows jenkins to run the ansible run in a seperate job
over ssh.